### PR TITLE
Change IMC bitmask from OR to XOR

### DIFF
--- a/xivModdingFramework/Mods/FileTypes/PMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/PMP.cs
@@ -398,7 +398,7 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
                                 var opt = group.Options[i] as PmpImcOptionJson;
                                 optionIdx++;
 
-                                xivImc.AttributeMask |= opt.AttributeMask;
+                                xivImc.AttributeMask ^= opt.AttributeMask;
                             }
                         }
 


### PR DESCRIPTION
Currently, default IMC options cannot be toggled off during import because an OR operator is used:

If the default is set to 0111, then an option to disable C and enable D would apply a bitmask of 1100.
0111 | 1100 results in 1111 (C is still enabled), while 0111 ^ 1100 results in 1011 (C is correctly disabled).